### PR TITLE
Add admin dashboard and CRM leads management (UI, actions, API, auth, tests)

### DIFF
--- a/app/(shop)/admin/crm/loading.tsx
+++ b/app/(shop)/admin/crm/loading.tsx
@@ -1,0 +1,5 @@
+import styles from "@/app/styles/admin.module.css"
+
+export default function LoadingCRMPage() {
+    return <main className={styles.wrapper}>Загрузка CRM-лидов...</main>
+}

--- a/app/(shop)/admin/crm/page.tsx
+++ b/app/(shop)/admin/crm/page.tsx
@@ -1,0 +1,61 @@
+import Link from "next/link"
+import { getCRMLeads } from "@/app/lib/data"
+import { requireAdminSession } from "@/app/lib/admin-auth"
+import { LeadUpdateForm } from "@/app/ui/admin/lead-update-form"
+import type { LeadStatus } from "@/app/lib/definitions"
+import styles from "@/app/styles/admin.module.css"
+import { isLeadStatus } from "@/app/lib/admin-utils"
+import { getAdminRequestError } from "@/app/lib/admin-screen-utils"
+
+const statuses: LeadStatus[] = ["NEW", "IN_PROGRESS", "WON", "LOST"]
+
+export default async function AdminCRMPage({
+    searchParams,
+}: {
+    searchParams: Promise<{ status_filter?: LeadStatus }>
+}) {
+    const params = await searchParams
+    const statusFilter = isLeadStatus(params.status_filter)
+        ? (params.status_filter as LeadStatus)
+        : undefined
+
+    const session = await requireAdminSession()
+    const leads = await getCRMLeads({ authToken: session.token, statusFilter })
+
+    if (typeof leads === "number") {
+        return <p className={styles.wrapper}>{getAdminRequestError(leads, "лидов")}</p>
+    }
+
+    return (
+        <main className={styles.wrapper}>
+            <h1 className={styles.title}>CRM лиды</h1>
+            <div className={styles.topActions}>
+                <Link href="/admin">← К dashboard</Link>
+                <form action="/admin/crm">
+                    <select name="status_filter" defaultValue={statusFilter ?? ""} className={styles.select}>
+                        <option value="">Все статусы</option>
+                        {statuses.map((status) => (
+                            <option key={status} value={status}>{status}</option>
+                        ))}
+                    </select>
+                    <button className={styles.button} type="submit">Фильтровать</button>
+                </form>
+            </div>
+
+            {leads.length === 0 ? (
+                <p>Лидов не найдено.</p>
+            ) : (
+                <section className={styles.leadList}>
+                    {leads.map((lead) => (
+                        <article key={lead.id} className={styles.leadCard}>
+                            <p className={styles.meta}>
+                                Лид #{lead.id} · {lead.name ?? "Без имени"} · {lead.phone ?? lead.email ?? "контакт не указан"}
+                            </p>
+                            <LeadUpdateForm lead={lead} />
+                        </article>
+                    ))}
+                </section>
+            )}
+        </main>
+    )
+}

--- a/app/(shop)/admin/loading.tsx
+++ b/app/(shop)/admin/loading.tsx
@@ -1,0 +1,5 @@
+import styles from "@/app/styles/admin.module.css"
+
+export default function LoadingAdminPage() {
+    return <main className={styles.wrapper}>Загрузка admin-данных...</main>
+}

--- a/app/(shop)/admin/page.tsx
+++ b/app/(shop)/admin/page.tsx
@@ -1,0 +1,41 @@
+import Link from "next/link"
+import { getAdminDashboard } from "@/app/lib/data"
+import { requireAdminSession } from "@/app/lib/admin-auth"
+import { ToggleAdminRoleForm } from "@/app/ui/admin/toggle-admin-role-form"
+import styles from "@/app/styles/admin.module.css"
+import { getAdminRequestError } from "@/app/lib/admin-screen-utils"
+
+export default async function AdminPage() {
+    const session = await requireAdminSession()
+    const dashboard = await getAdminDashboard(session.token)
+
+    if (typeof dashboard === "number") {
+        return <p className={styles.wrapper}>{getAdminRequestError(dashboard, "dashboard")}</p>
+    }
+
+    return (
+        <main className={styles.wrapper}>
+            <h1 className={styles.title}>Admin Dashboard</h1>
+
+            <div className={styles.topActions}>
+                <Link href="/admin/crm">Перейти к CRM-лидам</Link>
+            </div>
+
+            <section>
+                <h2 className={styles.subtitle}>Метрики</h2>
+                <div className={styles.cards}>
+                    <article className={styles.card}><p className={styles.cardLabel}>Пользователи</p><p className={styles.cardValue}>{dashboard.users_total}</p></article>
+                    <article className={styles.card}><p className={styles.cardLabel}>Админы</p><p className={styles.cardValue}>{dashboard.admins_total}</p></article>
+                    <article className={styles.card}><p className={styles.cardLabel}>Продукты</p><p className={styles.cardValue}>{dashboard.products_total}</p></article>
+                    <article className={styles.card}><p className={styles.cardLabel}>CRM лиды</p><p className={styles.cardValue}>{dashboard.crm_leads_total}</p></article>
+                    <article className={styles.card}><p className={styles.cardLabel}>Новые лиды</p><p className={styles.cardValue}>{dashboard.crm_new_leads}</p></article>
+                </div>
+            </section>
+
+            <section>
+                <h2 className={styles.subtitle}>Управление ролью пользователя</h2>
+                <ToggleAdminRoleForm />
+            </section>
+        </main>
+    )
+}

--- a/app/actions/admin.ts
+++ b/app/actions/admin.ts
@@ -1,0 +1,99 @@
+"use server"
+
+import { revalidatePath } from "next/cache"
+import {
+    ToggleAdminRoleSchema,
+    UpdateLeadSchema,
+} from "@/app/lib/definitions"
+import { patchAdminRole, patchCRMLead } from "@/app/lib/data"
+import { requireAdminSession } from "@/app/lib/admin-auth"
+import { toAssignedManagerId } from "@/app/lib/admin-utils"
+
+type AdminActionState = {
+    errors?: Record<string, string[] | undefined>
+    message?: string
+    success?: string
+}
+
+export async function updateLeadAction(state: AdminActionState, formData: FormData): Promise<AdminActionState> {
+    const session = await requireAdminSession()
+
+    const validatedFields = UpdateLeadSchema.safeParse({
+        leadId: formData.get("lead_id"),
+        status: formData.get("status"),
+        comment: formData.get("comment") ?? undefined,
+        assigned_manager_id: formData.get("assigned_manager_id")
+            ? formData.get("assigned_manager_id")
+            : undefined,
+    })
+
+    if (!validatedFields.success) {
+        return {
+            errors: validatedFields.error.flatten().fieldErrors,
+        }
+    }
+
+    const response = await patchCRMLead({
+        authToken: session.token,
+        leadId: validatedFields.data.leadId,
+        payload: {
+            status: validatedFields.data.status,
+            comment: validatedFields.data.comment,
+            assigned_manager_id: toAssignedManagerId(validatedFields.data.assigned_manager_id),
+        },
+    })
+
+    if (response === 401) {
+        return { message: "Сессия истекла. Войдите заново." }
+    }
+
+    if (response === 403) {
+        return { message: "Недостаточно прав для обновления лида." }
+    }
+
+    if (typeof response === "number") {
+        return { message: "Не удалось обновить лид." }
+    }
+
+    revalidatePath("/admin/crm")
+    return { success: "Лид обновлён." }
+}
+
+export async function toggleAdminRoleAction(
+    state: AdminActionState,
+    formData: FormData,
+): Promise<AdminActionState> {
+    const session = await requireAdminSession()
+
+    const validatedFields = ToggleAdminRoleSchema.safeParse({
+        target_user_id: formData.get("target_user_id"),
+        is_admin: formData.get("is_admin") === "on",
+    })
+
+    if (!validatedFields.success) {
+        return {
+            errors: validatedFields.error.flatten().fieldErrors,
+        }
+    }
+
+    const response = await patchAdminRole({
+        authToken: session.token,
+        targetUserId: validatedFields.data.target_user_id,
+        isAdmin: validatedFields.data.is_admin,
+    })
+
+    if (response === 401) {
+        return { message: "Сессия истекла. Войдите заново." }
+    }
+
+    if (response === 403) {
+        return { message: "Недостаточно прав для изменения роли." }
+    }
+
+    if (typeof response === "number") {
+        return { message: "Не удалось обновить роль пользователя." }
+    }
+
+    revalidatePath("/admin")
+    return { success: "Роль пользователя обновлена." }
+}

--- a/app/lib/admin-auth.ts
+++ b/app/lib/admin-auth.ts
@@ -1,0 +1,41 @@
+import { cookies } from "next/headers"
+import { redirect } from "next/navigation"
+import { decrypt } from "./sessions"
+import { getUserProfile } from "./data"
+
+type AdminSession = {
+    userId: string
+    token: string
+}
+
+export async function requireAdminSession(): Promise<AdminSession> {
+    const cookieStore = await cookies()
+    const cookie = cookieStore.get("session")
+
+    if (!cookie?.value) {
+        redirect("/sign-up")
+    }
+
+    const payload = await decrypt(cookie.value)
+    const userId = String(payload?.user_id ?? "")
+
+    if (!userId) {
+        redirect("/sign-up")
+    }
+
+    const profile = await getUserProfile({ userId, authToken: cookie.value })
+
+    if (profile === 401) {
+        redirect("/sign-up")
+    }
+
+    if (profile === 403) {
+        redirect("/?adminError=forbidden")
+    }
+
+    if (typeof profile === "number" || !profile.admin) {
+        redirect("/?adminError=forbidden")
+    }
+
+    return { userId, token: cookie.value }
+}

--- a/app/lib/admin-screen-utils.js
+++ b/app/lib/admin-screen-utils.js
@@ -1,0 +1,11 @@
+export function getAdminRequestError(statusCode, entityLabel) {
+    if (statusCode === 401) {
+        return "Сессия истекла. Авторизуйтесь повторно."
+    }
+
+    if (statusCode === 403) {
+        return "Доступ запрещён."
+    }
+
+    return `Ошибка загрузки ${entityLabel}.`
+}

--- a/app/lib/admin-utils.js
+++ b/app/lib/admin-utils.js
@@ -1,0 +1,22 @@
+const LEAD_STATUSES = ["NEW", "IN_PROGRESS", "WON", "LOST"]
+
+export function isLeadStatus(value) {
+    return typeof value === "string" && LEAD_STATUSES.includes(value)
+}
+
+export function buildCRMLeadsEndpoint(apiBaseUrl, statusFilter) {
+    if (!statusFilter || !isLeadStatus(statusFilter)) {
+        return `${apiBaseUrl}/crm/leads`
+    }
+
+    return `${apiBaseUrl}/crm/leads?status_filter=${statusFilter}`
+}
+
+export function toAssignedManagerId(value) {
+    if (value === undefined || value === null || value === "") {
+        return null
+    }
+
+    const parsed = Number(value)
+    return Number.isFinite(parsed) ? parsed : null
+}

--- a/app/lib/data.ts
+++ b/app/lib/data.ts
@@ -3,8 +3,13 @@ import {
     BestsellersSchema, 
     ProductSchema,
     UserProfileSchema,
+    CRMLeadSchema,
+    AdminDashboardSchema,
+    LeadStatus,
+    UpdateCRMLeadPayload,
 } from "./definitions"
 import { redirect } from "next/navigation"
+import { buildCRMLeadsEndpoint } from "./admin-utils"
 
 
 export async function getSearchProducts(query: string) {
@@ -263,5 +268,134 @@ export async function changeEmail(formData: FormData, authToken: string | undefi
 
     } catch (error) {
         console.error("Backend Error:", error);
+    }
+}
+
+const getApiBaseUrl = () =>
+    `${process.env.NEXT_PUBLIC_API_PROTOCOL}://${process.env.NEXT_PUBLIC_API}`
+
+export async function getAdminDashboard(authToken: string) {
+    try {
+        const response = await fetch(
+            `${getApiBaseUrl()}/admin/dashboard`,
+            {
+                headers: {
+                    "Authorization": `Bearer ${authToken}`,
+                    "accept": "application/json",
+                },
+                cache: "no-store",
+            },
+        )
+
+        if (response.ok) {
+            const dashboard: AdminDashboardSchema = await response.json()
+            return dashboard
+        }
+
+        return response.status
+    } catch (error) {
+        console.error("Backend Error:", error)
+        return 500
+    }
+}
+
+export async function getCRMLeads({
+    authToken,
+    statusFilter,
+}: {
+    authToken: string
+    statusFilter?: LeadStatus
+}) {
+    try {
+        const endpoint = buildCRMLeadsEndpoint(getApiBaseUrl(), statusFilter)
+
+        const response = await fetch(
+            endpoint,
+            {
+                headers: {
+                    "Authorization": `Bearer ${authToken}`,
+                    "accept": "application/json",
+                },
+                cache: "no-store",
+            },
+        )
+
+        if (response.ok) {
+            const leads: CRMLeadSchema[] = await response.json()
+            return leads
+        }
+
+        return response.status
+    } catch (error) {
+        console.error("Backend Error:", error)
+        return 500
+    }
+}
+
+export async function patchCRMLead({
+    authToken,
+    leadId,
+    payload,
+}: {
+    authToken: string
+    leadId: number
+    payload: UpdateCRMLeadPayload
+}) {
+    try {
+        const response = await fetch(
+            `${getApiBaseUrl()}/crm/leads/${leadId}`,
+            {
+                method: "PATCH",
+                headers: {
+                    "Authorization": `Bearer ${authToken}`,
+                    "accept": "application/json",
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify(payload),
+            },
+        )
+
+        if (response.ok) {
+            return await response.json()
+        }
+
+        return response.status
+    } catch (error) {
+        console.error("Backend Error:", error)
+        return 500
+    }
+}
+
+export async function patchAdminRole({
+    authToken,
+    targetUserId,
+    isAdmin,
+}: {
+    authToken: string
+    targetUserId: number
+    isAdmin: boolean
+}) {
+    try {
+        const response = await fetch(
+            `${getApiBaseUrl()}/admin/users/${targetUserId}/admin`,
+            {
+                method: "PATCH",
+                headers: {
+                    "Authorization": `Bearer ${authToken}`,
+                    "accept": "application/json",
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({ is_admin: isAdmin }),
+            },
+        )
+
+        if (response.ok) {
+            return await response.json()
+        }
+
+        return response.status
+    } catch (error) {
+        console.error("Backend Error:", error)
+        return 500
     }
 }

--- a/app/lib/definitions.ts
+++ b/app/lib/definitions.ts
@@ -88,6 +88,22 @@ export const ChangeEmailSchema = z.object({
     email: z.string().email({ message: "Пожалуйста, введите корректный email" }).nullable(),
 })
 
+export const LeadStatusSchema = z.enum(["NEW", "IN_PROGRESS", "WON", "LOST"])
+
+export const UpdateLeadSchema = z.object({
+    leadId: z.coerce.number().int().positive({ message: "Некорректный ID лида" }),
+    status: LeadStatusSchema,
+    comment: z.string().max(2000, { message: "Комментарий слишком длинный" }).optional(),
+    assigned_manager_id: z
+        .union([z.coerce.number().int().positive(), z.nan()])
+        .optional(),
+})
+
+export const ToggleAdminRoleSchema = z.object({
+    target_user_id: z.coerce.number().int().positive({ message: "Некорректный ID пользователя" }),
+    is_admin: z.boolean(),
+})
+
 export type FormState =
   | {
       errors?: {
@@ -185,4 +201,31 @@ export type UserProfileSchema = {
     email: string,
     admin: boolean,
     created_at: string
+}
+
+export type LeadStatus = z.infer<typeof LeadStatusSchema>
+
+export type CRMLeadSchema = {
+    id: number
+    status: LeadStatus
+    created_at?: string
+    name?: string | null
+    phone?: string | null
+    email?: string | null
+    comment?: string | null
+    assigned_manager_id?: number | null
+}
+
+export type UpdateCRMLeadPayload = {
+    status: LeadStatus
+    comment?: string | null
+    assigned_manager_id?: number | null
+}
+
+export type AdminDashboardSchema = {
+    users_total: number
+    admins_total: number
+    products_total: number
+    crm_leads_total: number
+    crm_new_leads: number
 }

--- a/app/styles/admin.module.css
+++ b/app/styles/admin.module.css
@@ -1,0 +1,113 @@
+.wrapper {
+  max-width: 1100px;
+  margin: 32px auto;
+  padding: 0 16px 48px;
+}
+
+.title {
+  font-size: 32px;
+  font-weight: 700;
+  margin-bottom: 20px;
+}
+
+.subtitle {
+  font-size: 22px;
+  margin: 24px 0 12px;
+}
+
+.cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 12px;
+}
+
+.card {
+  border: 1px solid #ddd;
+  border-radius: 10px;
+  padding: 14px;
+}
+
+.cardLabel {
+  font-size: 13px;
+  color: #555;
+}
+
+.cardValue {
+  font-size: 28px;
+  font-weight: 700;
+}
+
+.form {
+  display: grid;
+  gap: 10px;
+  max-width: 420px;
+  border: 1px solid #ddd;
+  border-radius: 10px;
+  padding: 14px;
+}
+
+.input,
+.select,
+.textarea {
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  padding: 9px 10px;
+  font-size: 14px;
+}
+
+.textarea {
+  min-height: 90px;
+  resize: vertical;
+}
+
+.button {
+  width: fit-content;
+  background: #111;
+  color: #fff;
+  border: 0;
+  border-radius: 8px;
+  padding: 8px 12px;
+  cursor: pointer;
+}
+
+.statusRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.message {
+  font-size: 14px;
+}
+
+.error {
+  color: #c62828;
+}
+
+.success {
+  color: #2e7d32;
+}
+
+.leadList {
+  display: grid;
+  gap: 14px;
+  margin-top: 14px;
+}
+
+.leadCard {
+  border: 1px solid #ddd;
+  border-radius: 10px;
+  padding: 14px;
+}
+
+.meta {
+  font-size: 14px;
+  color: #555;
+  margin-bottom: 8px;
+}
+
+.topActions {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}

--- a/app/ui/admin/lead-update-form.tsx
+++ b/app/ui/admin/lead-update-form.tsx
@@ -1,0 +1,51 @@
+"use client"
+
+import { useActionState } from "react"
+import { updateLeadAction } from "@/app/actions/admin"
+import type { CRMLeadSchema, LeadStatus } from "@/app/lib/definitions"
+import styles from "@/app/styles/admin.module.css"
+
+const initialState: { message?: string; success?: string } = {}
+
+const leadStatuses: LeadStatus[] = ["NEW", "IN_PROGRESS", "WON", "LOST"]
+
+export function LeadUpdateForm({ lead }: { lead: CRMLeadSchema }) {
+    const [state, action, isPending] = useActionState(updateLeadAction, initialState)
+
+    return (
+        <form action={action} className={styles.form}>
+            <input type="hidden" name="lead_id" value={lead.id} />
+
+            <label htmlFor={`status-${lead.id}`}>Статус</label>
+            <select id={`status-${lead.id}`} name="status" defaultValue={lead.status} className={styles.select}>
+                {leadStatuses.map((status) => (
+                    <option key={status} value={status}>{status}</option>
+                ))}
+            </select>
+
+            <label htmlFor={`comment-${lead.id}`}>Комментарий</label>
+            <textarea
+                id={`comment-${lead.id}`}
+                name="comment"
+                defaultValue={lead.comment ?? ""}
+                className={styles.textarea}
+            />
+
+            <label htmlFor={`manager-${lead.id}`}>ID менеджера</label>
+            <input
+                id={`manager-${lead.id}`}
+                name="assigned_manager_id"
+                type="number"
+                defaultValue={lead.assigned_manager_id ?? ""}
+                className={styles.input}
+            />
+
+            <button type="submit" className={styles.button} disabled={isPending}>
+                {isPending ? "Сохраняем..." : "Сохранить лид"}
+            </button>
+
+            {state?.message ? <p className={`${styles.message} ${styles.error}`}>{state.message}</p> : null}
+            {state?.success ? <p className={`${styles.message} ${styles.success}`}>{state.success}</p> : null}
+        </form>
+    )
+}

--- a/app/ui/admin/toggle-admin-role-form.tsx
+++ b/app/ui/admin/toggle-admin-role-form.tsx
@@ -1,0 +1,30 @@
+"use client"
+
+import { useActionState } from "react"
+import { toggleAdminRoleAction } from "@/app/actions/admin"
+import styles from "@/app/styles/admin.module.css"
+
+const initialState: { message?: string; success?: string } = {}
+
+export function ToggleAdminRoleForm() {
+    const [state, action, isPending] = useActionState(toggleAdminRoleAction, initialState)
+
+    return (
+        <form action={action} className={styles.form}>
+            <label htmlFor="target_user_id">ID пользователя</label>
+            <input id="target_user_id" name="target_user_id" type="number" className={styles.input} required />
+
+            <label className={styles.statusRow}>
+                <input name="is_admin" type="checkbox" />
+                Выдать admin права
+            </label>
+
+            <button type="submit" className={styles.button} disabled={isPending}>
+                {isPending ? "Сохраняем..." : "Обновить роль"}
+            </button>
+
+            {state?.message ? <p className={`${styles.message} ${styles.error}`}>{state.message}</p> : null}
+            {state?.success ? <p className={`${styles.message} ${styles.success}`}>{state.success}</p> : null}
+        </form>
+    )
+}

--- a/app/ui/popup.tsx
+++ b/app/ui/popup.tsx
@@ -45,6 +45,12 @@ export const PopupMenu = () => {
                                 </span>
                                 <p>МАГАЗИН</p>
                             </a>
+                            <Link href="/admin" className={styles.navLink}>
+                                <span className={styles.icon}>
+                                    <ShopSVG color="#000" h={15} w={15}/>
+                                </span>
+                                <p>ADMIN</p>
+                            </Link>
                         </div>
                     </nav>
                     , document.body

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "typecheck": "tsc --noEmit",
+    "test": "node --test tests/**/*.test.mjs"
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",

--- a/tests/admin-api.test.mjs
+++ b/tests/admin-api.test.mjs
@@ -1,0 +1,24 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { buildCRMLeadsEndpoint, isLeadStatus, toAssignedManagerId } from '../app/lib/admin-utils.js'
+
+test('buildCRMLeadsEndpoint builds base endpoint without filter', () => {
+  const endpoint = buildCRMLeadsEndpoint('https://api.example.com', undefined)
+  assert.equal(endpoint, 'https://api.example.com/crm/leads')
+})
+
+test('buildCRMLeadsEndpoint adds status filter for valid status', () => {
+  const endpoint = buildCRMLeadsEndpoint('https://api.example.com', 'WON')
+  assert.equal(endpoint, 'https://api.example.com/crm/leads?status_filter=WON')
+})
+
+test('lead status helper validates expected statuses only', () => {
+  assert.equal(isLeadStatus('NEW'), true)
+  assert.equal(isLeadStatus('UNKNOWN'), false)
+})
+
+test('toAssignedManagerId normalizes values', () => {
+  assert.equal(toAssignedManagerId('14'), 14)
+  assert.equal(toAssignedManagerId(''), null)
+  assert.equal(toAssignedManagerId('abc'), null)
+})

--- a/tests/admin-screens.test.mjs
+++ b/tests/admin-screens.test.mjs
@@ -1,0 +1,15 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { getAdminRequestError } from '../app/lib/admin-screen-utils.js'
+
+test('screen error helper returns auth message for 401', () => {
+  assert.equal(getAdminRequestError(401, 'dashboard'), 'Сессия истекла. Авторизуйтесь повторно.')
+})
+
+test('screen error helper returns forbidden message for 403', () => {
+  assert.equal(getAdminRequestError(403, 'лидов'), 'Доступ запрещён.')
+})
+
+test('screen error helper returns generic message for unexpected errors', () => {
+  assert.equal(getAdminRequestError(500, 'лидов'), 'Ошибка загрузки лидов.')
+})


### PR DESCRIPTION
### Motivation
- Provide an admin section with a dashboard and CRM leads management UI so admins can view metrics and manage leads and user roles.
- Secure admin routes by requiring and validating an admin session and centralize admin-specific utilities and error handling.

### Description
- Add admin pages and loading states with `app/(shop)/admin/page.tsx`, `app/(shop)/admin/crm/page.tsx`, and corresponding `loading.tsx` files that use `requireAdminSession`, `getAdminDashboard`, and `getCRMLeads`.
- Implement server actions in `app/actions/admin.ts` for `updateLeadAction` and `toggleAdminRoleAction` that validate input against schemas and call `patchCRMLead` and `patchAdminRole` then `revalidatePath` on success.
- Add admin auth helper `requireAdminSession` in `app/lib/admin-auth.ts` to decrypt session cookies and enforce admin access via `getUserProfile`.
- Introduce admin utilities and screen helpers in `app/lib/admin-utils.js` and `app/lib/admin-screen-utils.js` and extend `app/lib/data.ts` with `getAdminDashboard`, `getCRMLeads`, `patchCRMLead`, and `patchAdminRole` API clients.
- Extend `app/lib/definitions.ts` with `LeadStatusSchema`, `UpdateLeadSchema`, `ToggleAdminRoleSchema`, and types `CRMLeadSchema`, `UpdateCRMLeadPayload`, and `AdminDashboardSchema`.
- Add client UI components `LeadUpdateForm` and `ToggleAdminRoleForm` under `app/ui/admin/` that use `useActionState` and the new actions, and create `app/styles/admin.module.css` for admin styling.
- Add admin link to the main popup menu in `app/ui/popup.tsx` and update `package.json` with `typecheck` and `test` scripts.
- Add unit tests `tests/admin-api.test.mjs` and `tests/admin-screens.test.mjs` covering `admin-utils` and `admin-screen-utils` helpers.

### Testing
- Ran the new unit tests with `node --test tests/**/*.test.mjs` (via the `test` script) and all tests passed.
- Ran TypeScript type checking with `tsc --noEmit` (via the `typecheck` script) and the typecheck completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb71d431c88323a29b3e28880da22e)